### PR TITLE
fix: vp_formats for client metadata, not vp_formats_supported

### DIFF
--- a/draft-oid4vc-haip-sd-jwt-vc.md
+++ b/draft-oid4vc-haip-sd-jwt-vc.md
@@ -337,7 +337,7 @@ The following is a non-normative example of a Credential Response with Credentia
 
 ### Verifier Metadata
 
-The Verifier SHOULD add a `vp_formats_supported` element to its metadata (e.g. in the `client_metadata` authorization request parameter) to let the wallet know what protection algorithms it supports in conjunction with SD-JWT VCs. The format element MUST have the key `vc+sd-jwt`, the value is an object consisting of the following elements:
+The Verifier SHOULD add a `vp_formats` element to its metadata (e.g. in the `client_metadata` authorization request parameter) to let the wallet know what protection algorithms it supports in conjunction with SD-JWT VCs. The format element MUST have the key `vc+sd-jwt`, the value is an object consisting of the following elements:
 
 * `sd-jwt_alg_values`: OPTIONAL. A JSON array containing identifiers of cryptographic algorithms the verifier supports for protection of a SD-JWT. If present, the `alg` JOSE header (as defined in [@!RFC7515]) of the presented SD-JWT MUST match one of the array values.
 * `kb-jwt_alg_values`: OPTIONAL. A JSON array containing identifiers of cryptographic algorithms the verifier supports for protection of a KB-JWT. If present, the `alg` JOSE header (as defined in [@!RFC7515]) of the presented KB-JWT MUST match one of the array values.


### PR DESCRIPTION
According to:

- [OpenID4VP Section-5.1-9 ](https://openid.github.io/OpenID4VP/openid-4-verifiable-presentations-wg-draft.html#section-5.1-9)
- the non-normative example reported below, 

`vp_formats_supported` belongs to the wallet metadata and not to the verifier metadata/request

````
The following is a non-normative example of client_metadata request parameter value in a request to present a SD-JWT VC.

{
    "vp_formats": {
        "vc+sd-jwt": {
            "sd-jwt_alg_values": [
                "ES256",
                "ES384"
            ],
            "kb-jwt_alg_values": [
                "ES256",
                "ES384"
            ]
        }
    }
}
````

for this reason this PR changed `vp_formats_supported` in `vp_formats` because it is related to verifier's metadata