### PR TITLE
fix: update to vct

### DIFF
--- a/draft-oid4vc-haip-sd-jwt-vc.md
+++ b/draft-oid4vc-haip-sd-jwt-vc.md
@@ -301,7 +301,7 @@ The following is a non-normative example of an object comprising `credentials_su
 
 The following additional claims are defined for this Credential format.
 
-* `credential_definition`: REQUIRED. JSON object containing the detailed description of the credential type. It MUST contain at least `type` property as defined in (#server_metadata_vc_sd-jwt).
+* `credential_definition`: REQUIRED. JSON object containing the detailed description of the credential type. It MUST contain at least `vct` property as defined in (#server_metadata_vc_sd-jwt).
 
 The following is a non-normative example of an object comprising `credentials_supported` parameter of Credential format `vc+sd-jwt`.
 
@@ -311,7 +311,7 @@ The following is a non-normative example of an object comprising `credentials_su
 
 The following additional claims are defined for authorization details of type `openid_credential` and this Credential format.
 
-* `credential_definition`: REQUIRED.  JSON object containing the detailed description of the credential type. It MUST contain at least `type` property as defined in (#server_metadata_vc_sd-jwt). It MAY contain `claims` property as defined in (#server_metadata_vc_sd-jwt).
+* `credential_definition`: REQUIRED.  JSON object containing the detailed description of the credential type. It MUST contain at least `vct` property as defined in (#server_metadata_vc_sd-jwt). It MAY contain `claims` property as defined in (#server_metadata_vc_sd-jwt).
 
 The following is a non-normative example of an authorization details object with Credential format `vc+sd-jwt`.
 

--- a/examples/authorization_details_sd_jwt_vc.json
+++ b/examples/authorization_details_sd_jwt_vc.json
@@ -3,7 +3,7 @@
         "type": "openid_credential",
         "format": "vc+sd-jwt",
         "credential_definition": {
-            "type": "IdentityCredential"
+            "vct": "IdentityCredential"
         }
     }
 ]

--- a/examples/credential_metadata_sd_jwt_vc.json
+++ b/examples/credential_metadata_sd_jwt_vc.json
@@ -16,7 +16,7 @@
         }
     ],
     "credential_definition": {
-        "type": "IdentityCredential",
+        "vct": "IdentityCredential",
         "claims": {
             "given_name": {
                 "display": [
@@ -60,7 +60,7 @@
 
 
 {
-    "type": "IdentityCredential",
+    "vct": "IdentityCredential",
     "given_name": "John",
     "family_name": "Doe",
 }

--- a/examples/credential_request_sd_jwt_vc.json
+++ b/examples/credential_request_sd_jwt_vc.json
@@ -1,7 +1,7 @@
 {
    "format": "vc+sd-jwt",
    "credential_definition": {
-      "type": "IdentityCredential"
+      "vct": "IdentityCredential"
    },
    "proof": {
       "proof_type": "jwt",

--- a/examples/presentation_definition_sd_jwt_vc.json
+++ b/examples/presentation_definition_sd_jwt_vc.json
@@ -11,7 +11,7 @@
                 "fields": [
                     {
                         "path": [
-                            "$.type"
+                            "$.vct"
                         ],
                         "filter": {
                             "type": "string",


### PR DESCRIPTION
## 📑 Description

A few days ago a PR was merged that changes the `type` property to `vct`, however this was not reflected in all examples and parts of the spec