### PR TITLE
fix typo in verifier metadata

### DIFF
--- a/draft-oid4vc-haip-sd-jwt-vc.md
+++ b/draft-oid4vc-haip-sd-jwt-vc.md
@@ -337,7 +337,7 @@ The following is a non-normative example of a Credential Response with Credentia
 
 ### Verifier Metadata
 
-The Verifier SHOULD add a `vp_formats_supported` element to its metadata (e.g. in the `client_metadata` authorization request parameter) to let the wallet know what protection algorithms it supports in conjunction with SD-JWT VCs. The format element MUST have the key `vc+sd-jwt`, the value is an object consisting of the following elements:
+The Verifier SHOULD add a `vp_formats` element to its metadata (e.g. in the `client_metadata` authorization request parameter) to let the wallet know what protection algorithms it supports in conjunction with SD-JWT VCs. The format element MUST have the key `vc+sd-jwt`, the value is an object consisting of the following elements:
 
 * `sd-jwt_alg_values`: OPTIONAL. A JSON array containing identifiers of cryptographic algorithms the verifier supports for protection of a SD-JWT. If present, the `alg` JOSE header (as defined in [@!RFC7515]) of the presented SD-JWT MUST match one of the array values.
 * `kb-jwt_alg_values`: OPTIONAL. A JSON array containing identifiers of cryptographic algorithms the verifier supports for protection of a KB-JWT. If present, the `alg` JOSE header (as defined in [@!RFC7515]) of the presented KB-JWT MUST match one of the array values.


### PR DESCRIPTION
There seems to be a typo in the verifier metadata section, where the text mentions `vp_formats_supported` but references the verifier (which would use `vp_formats` instead) and the examples also show `vp_formats`