### PR TITLE
Remove requirement to support the non-longer existing batch endpoint

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -420,10 +420,6 @@ The security considerations in [@!OIDF.OID4VCI] and [@!OIDF.OID4VP] apply.
         </front>
 </reference>
 
-# Combined Issuance of SD-JWT VC and mdocs
-
-* If combined issuance is required, the Batch Credential Endpoint MUST be supported.
-
 # Acknowledgements {#Acknowledgements}
 
 We would like to thank Paul Bastian, Christian Bormann, Mike Jones, Oliver Terbu, Daniel Fett, and Giuseppe De Marco for their valuable feedback and contributions to this specification.


### PR DESCRIPTION
There don't seem to be any sensible requirements we can put on combined issuance so remove that section as well as this was the only thing in it, and any requirements around combined issuance would fit between in section 4. (I've left in the reference that allowing combine issuance is a goal of the specification though.)

closes #195