### PR TITLE
Clarify exactly which wallet attestation JWT the x5c header goes into.

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -147,7 +147,7 @@ Note: Issuers should be mindful of how long the usage of the refresh token is al
 
 Wallets MUST use wallet attestations as defined in Annex E of [@!OIDF.OID4VCI].
 
-The public key, and optionally a trust chain, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT.
+The public key certificate, and optionally a trust certificate chain, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT.
 
 ## Credential Endpoint
 


### PR DESCRIPTION
Feedback from the interop was that some implementers seem to be struggling to understand this (though I think this is literally the only place it could go), maybe this change helps.