### PR TITLE
Remove ‘Validity Period of the Signature and the Claim Values’ section, again

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -291,10 +291,6 @@ When using this profile alongside other hash algorithms, each entity SHOULD make
 
 # Implementations Considerations
 
-## Validity Period of the Signature and the Claim Values
-
-`iat` and `exp` JWT claims express both the validity period of both the signature and the claims about the subject, unless there is a separate claim used to express the validity of the claims.
-
 ## Interoperable Key Attestations
 
 Wallet implementations using the key attestation format specified in Annex D of [@!OIDF.OID4VCI] might need to utilize a transformation (backend) service to create such attestations based on data as provided in other formats by the respective platform or secure key management module. The dependency on such a service might impact the availability of the wallet app as well as the performance of the issuance process. This could be mitigated by creating keys and obtaining the respective key attestations in advance.


### PR DESCRIPTION
This is a bizarre case. The section ‘Validity Period of the Signature and the Claim Values’ was removed in commit 8875d9695f396c4ad386e4d7db2c7212b4a9108d (introduced in pull request https://github.com/openid/OpenID4VC-HAIP/pull/165).

Since then the section has been re-added, but curiously git does not show its addition in `git log -p` nor in the diff of the commit. The section is not there in the commit 7a76da65cdcbe5a212aa812e793db01abe67ff11 (https://github.com/openid/OpenID4VC-HAIP/blob/7a76da65cdcbe5a212aa812e793db01abe67ff11/openid4vc-high-assurance-interoperability-profile-1_0.md#implementations-considerations), but in the following commit 5b0f97ffbd55c1715fdd299705aff03990848409 (https://github.com/openid/OpenID4VC-HAIP/blob/5b0f97ffbd55c1715fdd299705aff03990848409/openid4vc-high-assurance-interoperability-profile-1_0.md#implementations-considerations) the section has made its surprising reappareance without appearing in the diff. Very strange.

This pull request removes the section, again. I re-opened issue https://github.com/openid/OpenID4VC-HAIP/issues/164 due to this.