### PR TITLE
Remove bullet about ARF in scenarios section, rename section

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -119,7 +119,7 @@ Assumptions made are the following:
 * There are mechanisms in place for Wallets to discover Verifiers' capabilities
 * There are mechanisms in place for Issuers to discover Wallets' capabilities
 
-## Additional scenarios:
+## Additional scenarios
 
 Below is a non-exhaustive list of scenarios that can be realized with this specification:
 


### PR DESCRIPTION
It's already covered in the scope section.

closes #4