### PR TITLE
Tweak 'This document is not a specification' text

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -63,7 +63,7 @@ Note: This profile defines the technical means by which holder authentication ca
 
 Note: This specification fulfils some, but not all, of the requirements to meet the "High" Level of Assurance (LoA) as defined in the eIDAS Regulation [@eIDAS2.0]. While this profile defines features intended for scenarios targeting a high level of security, these features must be combined with additional measures outside of the scope of HAIP to achieve LoA High compliance.
 
-This document contains a profile of existing specifications. It refers to the specifications required for implementations to interoperate among each other and for the optionalities mentioned in the referenced specifications, defines the set of features to be mandatory to implement.
+This specification contains profiles of other specifications. It refers to the specifications required for implementations to interoperate among each other and for the optionalities mentioned in the referenced specifications, defines the set of features to be mandatory to implement.
 
 The profile uses OpenID for Verifiable Credential Issuance [@!OIDF.OID4VCI] and OpenID for Verifiable Presentations [@!OIDF.OID4VP] as the base protocols for issuance and presentation of Credentials, respectively. The credential formats used are IETF SD-JWT VC as specified in [@!I-D.ietf-oauth-sd-jwt-vc] and ISO mdoc [@!ISO.18013-5]. Additionally, considerations are given on how the issuance of Credentials in both IETF SD-JWT VC [@!I-D.ietf-oauth-sd-jwt-vc] and ISO mdoc [@ISO.18013-5] formats can be performed in the same transaction.
 


### PR DESCRIPTION
We have the sentence "This document is not a specification, but a profile.", but then use the word "specification" a lot to describe the document.

The required OIDF "Notices" boilerplate text also refers to it as a specifications, so reword the 'not a specification' text instead so we at least don't immediately contradict ourselves.

(Based on a suggestion from Brian Campbell.)