### PR TITLE
Make clear that digital sig section applies to jwt proof type too

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -350,9 +350,9 @@ This specification mandates the support for X.509 certificate-based key resoluti
 Issuers, Verifiers, and Wallets MUST, at a minimum, support ECDSA with P-256 and SHA-256 (JOSE algorithm identifier `ES256`; COSE algorithm identifier `-7` or `-9`, as applicable) for the purpose of validating the following:
 
 - Issuers
-  - Wallet Attestations (including PoP) when Annex E of [@!OIDF.OID4VCI] is used;
+  - Wallet Attestations (including PoP) when Annex E of [@!OIDF.OID4VCI] is used.
   - Key Attestations when Annex D of [@!OIDF.OID4VCI] is used.
-  - `jwt` proof type as specified in Appendix E of [@!OIDF.OID4VCI]
+  - `jwt` proof type as specified in Appendix E of [@!OIDF.OID4VCI].
 - Verifiers
   - the signature of the Verifiable Presentation, e.g., KB-JWT of an SD-JWT VC, or `deviceSignature` CBOR structure in case of ISO mdocs. Verifiers are assumed to determine in advance the cryptographic suites supported by the ecosystem, e.g. mDL Issuers/Verifiers implementing ISO mdocs.
   - the status information of the Verifiable Credential or Wallet Attestation.


### PR DESCRIPTION
Already nominally the case given it's specified for the key binding jwt, but this makes it much clearer.

closes #342