### PR TITLE
add pre-final specifications note and update references

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -564,7 +564,7 @@ Wallet implementations using the key attestation format specified in Appendix D 
 
 <reference anchor="ISO.18013-5.second.edition" target="https://www.iso.org/standard/91081.html">
         <front>
-          <title>ISO/IEC 18013-5:xxxx Personal identification — ISO-compliant drving license — Part 5: Mobile driving license (mDL)  application edition 2</title>
+          <title>ISO/IEC 18013-5:xxxx Personal identification — ISO-compliant driving license — Part 5: Mobile driving license (mDL)  application edition 2</title>
           <author>
             <organization>ISO/IEC JTC 1/SC 17 Cards and security devices for personal identification</organization>
           </author>


### PR DESCRIPTION
I only added specifications that are directly referenced in HAIP.

VCI & VP also reference (normatively):

- [I-D.ietf-jose-fully-specified-algorithms] (became RFC 9864)
- [I-D.ietf-oauth-attestation-based-client-auth] (no new draft version since VCI)

I think it's fine not mentioning those?